### PR TITLE
Bug fix for calculation of total pages

### DIFF
--- a/search-filtering-and-pagination/app.py
+++ b/search-filtering-and-pagination/app.py
@@ -51,9 +51,9 @@ def paginate_df(name: str, dataset, streamlit_object: str, disabled=None, num_ro
     with bottom_menu[2]:
         batch_size = st.selectbox("Page Size", options=[25, 50, 100], key=f"{name}")
     with bottom_menu[1]:
-        total_pages = (
-            int(len(dataset) / batch_size) if int(len(dataset) / batch_size) > 0 else 1
-        )
+        factor = 1 if len(dataset) % batch_size > 0 else 0
+        total_pages = int(len(dataset) / batch_size) + factor
+    
         current_page = st.number_input(
             "Page", min_value=1, max_value=total_pages, step=1
         )


### PR DESCRIPTION
Currently, total pages calculation is faulty. 

If total rows are 3 and batch size is 2, then according to the current code, total pages would be 1 -> len(dataset)/batch_size
It doesn't take into consideration the dividend after division. 
I've added that factor and now it works as expected. 

3 dataset rows and batch size 2 -> total pages = 2
3 dataset rows and batch size 3 -> total pages = 1
3 dataset rows and batch size 1 -> total pages = 3

Kindly consider the fix